### PR TITLE
Add company registration details to site footer

### DIFF
--- a/Contact.html
+++ b/Contact.html
@@ -116,6 +116,7 @@
 							<li>&copy; PD Marfleet 2025</li><li><a href="Privacy.html">Privacy Policy</a></li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
 							<img src="images/ExpensePlus Certified Trainers (PNG).png" alt="ExpensePlus Certified Trainers" style="max-width: 100px; height: auto; margin-top: 1em;" />
+						<p style="text-align:center; font-size:0.75em; color:rgba(255,255,255,0.4); margin-top:1em;">PD Marfleet Accounting Limited | Registered in England and Wales | Company No. 17236575 | Registered office: Unit 9 Innovation Centre, Conyngham Hall, Knaresborough, North Yorkshire, HG5 9AY</p>
 						</footer>
 	
 				</div>

--- a/Privacy.html
+++ b/Privacy.html
@@ -172,6 +172,7 @@
 						<ul class="copyright">
 							<li>&copy; PD Marfleet 2025</li><li><a href="Privacy.html">Privacy Policy</a></li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
+						<p style="text-align:center; font-size:0.75em; color:rgba(255,255,255,0.4); margin-top:1em;">PD Marfleet Accounting Limited | Registered in England and Wales | Company No. 17236575 | Registered office: Unit 9 Innovation Centre, Conyngham Hall, Knaresborough, North Yorkshire, HG5 9AY</p>
 						</footer>
 	
 				</div>

--- a/Resources.html
+++ b/Resources.html
@@ -139,6 +139,7 @@
 						<ul class="copyright">
 							<li>&copy; PD Marfleet 2025</li><li><a href="Privacy.html">Privacy Policy</a></li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
+						<p style="text-align:center; font-size:0.75em; color:rgba(255,255,255,0.4); margin-top:1em;">PD Marfleet Accounting Limited | Registered in England and Wales | Company No. 17236575 | Registered office: Unit 9 Innovation Centre, Conyngham Hall, Knaresborough, North Yorkshire, HG5 9AY</p>
 						</footer>
 
 			</div>

--- a/Training-Support.html
+++ b/Training-Support.html
@@ -339,6 +339,7 @@
 						<ul class="copyright">
 							<li>&copy; PD Marfleet 2025</li><li><a href="Privacy.html">Privacy Policy</a></li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
+						<p style="text-align:center; font-size:0.75em; color:rgba(255,255,255,0.4); margin-top:1em;">PD Marfleet Accounting Limited | Registered in England and Wales | Company No. 17236575 | Registered office: Unit 9 Innovation Centre, Conyngham Hall, Knaresborough, North Yorkshire, HG5 9AY</p>
 						</footer>
 
 			</div>

--- a/bookkeeping.html
+++ b/bookkeeping.html
@@ -280,6 +280,7 @@
 						<ul class="copyright">
 							<li>&copy; PD Marfleet 2025</li><li><a href="Privacy.html">Privacy Policy</a></li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
+						<p style="text-align:center; font-size:0.75em; color:rgba(255,255,255,0.4); margin-top:1em;">PD Marfleet Accounting Limited | Registered in England and Wales | Company No. 17236575 | Registered office: Unit 9 Innovation Centre, Conyngham Hall, Knaresborough, North Yorkshire, HG5 9AY</p>
 						</footer>
 
 			</div>

--- a/index.html
+++ b/index.html
@@ -477,6 +477,7 @@
 						<ul class="copyright">
 							<li>&copy; PD Marfleet 2025</li><li><a href="Privacy.html">Privacy Policy</a></li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
 							</ul>
+						<p style="text-align:center; font-size:0.75em; color:rgba(255,255,255,0.4); margin-top:1em;">PD Marfleet Accounting Limited | Registered in England and Wales | Company No. 17236575 | Registered office: Unit 9 Innovation Centre, Conyngham Hall, Knaresborough, North Yorkshire, HG5 9AY</p>
 						</footer>
 
 			</div>


### PR DESCRIPTION
PD Marfleet Accounting Limited | Registered in England and Wales | Company No. 17236575 | Registered office details.

Added to the 6 live pages; skipped unused HTML5UP template scaffolding (elements.html, generic.html, snipcart.html) and stripe-setup-charities.html (not linked anywhere).