### PR TITLE
Homepage reorder, price asterisks, pricing wording

### DIFF
--- a/Training-Support.html
+++ b/Training-Support.html
@@ -70,7 +70,7 @@
 						<header>
 							<img src="images/ExpensePlus-training-2.jpg" style="border-radius: 1em; margin-bottom: 20px;" width="200px">
 							<p>Training & Support</p>
-							<p style="text-transform: lowercase;">from £130 per month</p>
+							<p style="text-transform: lowercase;">from £130<sup>*</sup> per month</p>
 						</header>
 			
 				<!-- one -->
@@ -99,7 +99,7 @@
 									<header class="package">
 									<h3>Support Package</h3>
 									</header>
-									<p>from £440 per day</p>
+									<p>from £440<sup>*</sup> per day</p>
 									<p>With this option, we’ll put together a custom support package based on the specific training and support you need using ExpensePlus.</p>
 									<p>For example, it could vary from a 2 hour session with one of us to help your bookkeeper understand the basics of managing your accounts in ExpensePlus, or 1/2 a day training online for your wider team or a full day consulting on your fund architecture. It really is up to you to say how we can help.</p>
 									<a class="button" href="#popup1">Click for Prices</a>
@@ -117,16 +117,16 @@
 														<ul class="package-price" sytle="text-align:centre"> 
 																<li>
 																	<p style="margin:0!important;">​Charity income under £250k:</p>
-																	<p style="margin:0!important;">£440 per day</p>
+																	<p style="margin:0!important;">£440<sup>*</sup> per day</p>
 																</li>
 																<li>
 																	<p style="margin:0!important;">​Charity income over £250k:</p>
-																	<p style="margin:0!important;">£540 per day</p>
+																	<p style="margin:0!important;">£540<sup>*</sup> per day</p>
 																</li>
 																					
 																<li>
 																	<p style="margin:0!important;">​Charity income over £1M: </p>
-																	<p style="margin:0!important;">£640 per day</p>	
+																	<p style="margin:0!important;">£640<sup>*</sup> per day</p>
 																</li>
 																<li>
 																	<p style="margin:0!important;">​For charities under £50k:</p>
@@ -134,7 +134,7 @@
 																</li>
 															
 													</ul>
-													<p style="font-size:12px;margin-top:1em;">*Prices shown are exclusive of VAT where applicable.</p>
+													<p style="font-size:12px;margin-top:1em;"><sup>*</sup>Prices shown are exclusive of VAT where applicable.</p>
 												</div>
 
 															
@@ -154,7 +154,7 @@
 									<header class="package">
 									<h3>Support<span style="color: #ffcd00;font-weight: 900;">Plus</span> Package</h3>
 									</header>
-									<p>from £150 per month</p>
+									<p>from £150<sup>*</sup> per month</p>
 									<p>This option is for organisations who have a volunteer bookkeeper and are already using ExpensePlus, but would appreciate ongoing mentoring support.</p>
 									<p>It is offered on a 30-day rolling contract and includes unlimited<sup>*</sup> email and Zoom support for questions related to using ExpensePlus, along with advice for your trustees on financial best practices and good financial governance if needed.</p>
 									<p>With access to your ExpensePlus account via the ‘external bookkeeper’ system setting, we can provide detailed support and tailored mentoring to you as a bookkeeper, helping you resolve queries more effectively and build confidence in your financial processes.</p>
@@ -174,16 +174,16 @@
 														<ul class="package-price" sytle="text-align:centre"> 
 																<li>
 																	<p style="margin:0!important;">​Charity income under £250k:</p>
-																	<p style="margin:0!important;">£150 - £195 per month</p>
+																	<p style="margin:0!important;">£150 - £195<sup>*</sup> per month</p>
 																</li>
 																<li>
 																	<p style="margin:0!important;">​Charity income over £250k:</p>
-																	<p style="margin:0!important;">£200 - £490 per month</p>
+																	<p style="margin:0!important;">£200 - £490<sup>*</sup> per month</p>
 																</li>
 																					
 																<li>
 																	<p style="margin:0!important;">​Charity income over £1M: </p>
-																	<p style="margin:0!important;">£495+ per month</p>	
+																	<p style="margin:0!important;">£495+<sup>*</sup> per month</p>
 																</li>
 																<li>
 																	<p style="margin:0!important;">​For charities under £50k:</p>
@@ -191,7 +191,7 @@
 																</li>
 															
 													</ul>
-													<p style="font-size:12px;margin-top:1em;">*Prices shown are exclusive of VAT where applicable.</p>
+													<p style="font-size:12px;margin-top:1em;"><sup>*</sup>Prices shown are exclusive of VAT where applicable.</p>
 												</div>
 											
 															
@@ -227,19 +227,19 @@
 									<header class="package">
 									<h3>Migration Package</h3>
 									</header>
-									<p>from £880</p>
+									<p>from £880<sup>*</sup></p>
 									<p>If your organisation is considering migrating to ExpensePlus, the idea of switching to a new system may feel a bit daunting.</p>
 									<p style="margin-bottom:3.5em!important">To help ease the transition, we offer a custom support and training package specifically for charities who would appreciate more in-depth assistance in moving to ExpensePlus as quickly and efficiently as possible.</p></br>				
 									<a class="button" href="#popup2">Click for Prices</a>
 																
 									<div id="popup2" class="overlay">
 										<div class="popup">
-											<h2>Migration Package from £880</h2>
+											<h2>Migration Package from £880<sup>*</sup></h2>
 											<a class="close" href="#">&times;</a>
 											<a class="close topright" href="#">&times;</a>
 											<div class="content">
 												<p>If you are interested in moving to ExpensePlus, we will start with a free, no-obligation consultation via Zoom. This will enable us to learn more about you, your organisation, and your current accounting setup in greater depth.</p> 
-												<p>Each organisation's migration to ExpensePlus is unique, so the fees we charge vary from the basic package price of £880, depending on your organisation's income. In addition, if your accounts require significantly more work than usual before they can be transferred to ExpensePlus, the package price could increase. However, if we think your accounts are simple to migrate or you are a very small organisation (income less than £50K), we may be able to offer a rate lower than the base price ranges listed below.</p>
+												<p>Each organisation's migration to ExpensePlus is unique, so the fees we charge vary from the basic package price of £880<sup>*</sup>, depending on your organisation's income. In addition, if your accounts require significantly more work than usual before they can be transferred to ExpensePlus, the package price could increase. However, if we think your accounts are simple to migrate or you are a very small organisation (income less than £50K), we may be able to offer a rate lower than the base price ranges listed below.</p>
 											<section id="Reviews" style="margin-top:-200px; margin-bottom: 250px">
 											</section>
 					
@@ -247,23 +247,23 @@
 												<ul class="package-price" sytle="text-align:centre"> 
 														<li>
 															<p style="margin:0!important;">​Charity income under £250k:</p>
-															<p style="margin:0!important;">from £880</p>
+															<p style="margin:0!important;">from £880<sup>*</sup></p>
 														</li>
 														<li>
 															<p style="margin:0!important;">​Charity income over £250k:</p>
-															<p style="margin:0!important;">£1,215 - £1,650</p>
+															<p style="margin:0!important;">£1,215 - £1,650<sup>*</sup></p>
 														</li>
 																			
 														<li>
 															<p style="margin:0!important;">​Charity income over £1M: </p>
-															<p style="margin:0!important;">£1,950+</p>	
+															<p style="margin:0!important;">£1,950+<sup>*</sup></p>
 														</li>
 														<li>
 															<p style="margin:0!important;">​For charities under £50k:</p>
 															<p style="margin:0!important;">Reduced rates may be available, <a href="contact.html">let's talk</a></p>
 														</li>
 												</ul>
-											<p style="font-size:12px;margin-top:1em;">*Prices shown are exclusive of VAT where applicable.</p>
+											<p style="font-size:12px;margin-top:1em;"><sup>*</sup>Prices shown are exclusive of VAT where applicable.</p>
 											</div>
 					
 									

--- a/bookkeeping.html
+++ b/bookkeeping.html
@@ -77,7 +77,7 @@
 						<header>
 							<img src="images/expenseplus-cloud-accounting-software-for-charities.jpg" style="border-radius: 1em; margin-bottom: 20px;" width="50%">
 							<p>Outsourced Bookkeeping Consultant</p>
-							<p style="text-transform: lowercase;">from £545 per month </p>
+							<p style="text-transform: lowercase;">from £545<sup>*</sup> per month </p>
 							
 						</header>
 						</article>
@@ -94,11 +94,11 @@
 								<div id="popup-price" class="overlay">
 									<div class="popup">
 										<h2 style="color:#ffffff;">Bookkeeping<span style="color: #ffcd00;font-weight: 900;">Plus</span> Package</h2>
-										<p style="color:#ffffff!important; font-size: 20px!important;">Packages from £545 per month</p>
+										<p style="color:#ffffff!important; font-size: 20px!important;">Packages from £545<sup>*</sup> per month</p>
 										
 										<div class="content">
 								 
-								<p style="color:#ffffff!important;">Each organisation's bookkeeping on ExpensePlus is unique, so the fees we charge vary from the basic package price of £545 per month. However, if you are a very small organisation (income less than £50K), we may be able to offer a rate lower than the base price ranges listed below.</p>
+								<p style="color:#ffffff!important;">Each organisation's bookkeeping on ExpensePlus is unique, so the fees we charge vary from the basic package price of £545<sup>*</sup> per month. However, if you are a very small organisation (income less than £50K), we may be able to offer a rate lower than the base price ranges listed below.</p>
 								<section id="Reviews" style="margin-top:-200px; margin-bottom: 250px"></section>
 										
 					<div class="inner">
@@ -106,16 +106,16 @@
 							<ul class="package-price" sytle="text-align:centre" > 
 									<li>
 										<p style="color:#ffffff!important;margin:0!important;">​Charity income under £250k:</p>
-										<p style="color:#ffffff!important;margin:0!important;">£545 - £770 per month</p>
+										<p style="color:#ffffff!important;margin:0!important;">£545 - £770<sup>*</sup> per month</p>
 									</li>
 									<li>
 										<p style="color:#ffffff!important;margin:0!important;">​Charity income over £250k:</p>
-										<p style="color:#ffffff!important;margin:0!important;">£770 - £1350 per month</p>
+										<p style="color:#ffffff!important;margin:0!important;">£770 - £1350<sup>*</sup> per month</p>
 									</li>
 														
 									<li>
 										<p style="color:#ffffff!important;margin:0!important;">​Charity income over £1M: </p>
-										<p style="color:#ffffff!important;margin:0!important;">£1350 - £1,650 per month</p>	
+										<p style="color:#ffffff!important;margin:0!important;">£1350 - £1,650<sup>*</sup> per month</p>
 									</li>
 									<li>
 										<p style="color:#ffffff!important;margin:0!important;">​For charities under £50k:</p>
@@ -123,7 +123,7 @@
 									</li>
 
 						</ul>
-						<p style="color:#ffffff!important;font-size:12px;margin-top:1em;">*Prices shown are exclusive of VAT where applicable.</p>
+						<p style="color:#ffffff!important;font-size:12px;margin-top:1em;"><sup>*</sup>Prices shown are exclusive of VAT where applicable.</p>
 						<a class="close topright" href="#">&times;</a>
 						<a class="close" href="#">&times;</a>
 

--- a/index.html
+++ b/index.html
@@ -485,7 +485,7 @@
 							<header class="major">
 								<h2 style="text-transform: uppercase;">How Much Do Our Services Cost?</h2>
 							</header>
-							<p style="text-align: center;">Each of our clients is quoted specifically for the services tailored to their particular size and needs. As a general rule, our <a href="bookkeeping.html">BookkeepingPlus</a> service is priced in the region of 2-4% of a charity's annual income &mdash; see our <a href="bookkeeping.html">Bookkeeping</a> page for detailed pricing tiers.</p>
+							<p style="text-align: center;">Each of our clients is quoted specifically for the services tailored to their particular size and needs. As a general guide, our <a href="bookkeeping.html">BookkeepingPlus</a> service works out at roughly 2-4% of annual income for smaller charities, tapering down to around 1% or less for larger organisations &mdash; see our <a href="bookkeeping.html">Bookkeeping</a> page for detailed pricing tiers.</p>
 						</div>
 					</section>
 

--- a/index.html
+++ b/index.html
@@ -189,11 +189,34 @@
 		<div class="inner">
 			<header class="major">
 			<h2 style="text-transform: uppercase; color: white;">What Clients Say</h2>
-			<p style="font-size:.9em!important; margin-top:.5em!important; color: white!important;"><a href="https://www.google.com/maps/place/PD+Marfleet+Accounting/@45.8028319,-8.5003746,4z/data=!4m8!3m7!1s0x85a49e458d01948b:0x8a23e834d160a476!8m2!3d47.73855!4d12.5088275!9m1!1b1!16s%2Fg%2F11ssnp2wjq?hl=en-US&entry=ttu">on Google Reviews</a></p>
 			</header>
 		</div>
 	</section>
 	<!-- Section Header Ends -->
+
+	<!--video referrals-->
+	<div class="video-reviews-section" style="width:100%; padding:0 8% 40px; background-color:#218ea6;">
+		<div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); gap:2em; max-width:1100px; margin:0 auto;">
+			<!-- Video 1 -->
+			<div>
+				<iframe class="YT-video" src="https://www.youtube.com/embed/IWCUZTMvbfI?si=sRXMsiIrzrLMO9h8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+			</div>
+			<!-- Video 2 -->
+			<div>
+				<iframe class="YT-video" src="https://www.youtube.com/embed/KXeFs3Vq7Ak?si=BCQbIDEQCR0p19jx" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+			</div>
+			<!-- Video 3 -->
+			<div>
+				<iframe class="YT-video" src="https://www.youtube.com/embed/N0jaQ9dP2ws?si=nynpo89bikYvc3JS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+			</div>
+		</div>
+	</div>
+
+	<!-- Google Reviews link -->
+	<div style="width:100%; text-align:center; background-color:#218ea6; padding: 1em 8% 2em 8%;">
+		<p style="font-size:.9em!important; color: white!important;"><a href="https://www.google.com/maps/place/PD+Marfleet+Accounting/@45.8028319,-8.5003746,4z/data=!4m8!3m7!1s0x85a49e458d01948b:0x8a23e834d160a476!8m2!3d47.73855!4d12.5088275!9m1!1b1!16s%2Fg%2F11ssnp2wjq?hl=en-US&entry=ttu">on Google Reviews</a></p>
+	</div>
+
 	<div class="testimonials-section">
 	<!-- Owl Carousel Slider Starts -->
 		<div class="owl-carousel owl-theme testimonials-container">
@@ -442,32 +465,6 @@
     </div>
 	<!-- Owl Carousel Slider Ends -->
 
-</div>
-
-<!--video referrals styling-->
-<section id="video-reviews" class="wrapper style1 special" style="background-color: #218ea6!important; padding-bottom: 0.5em;">
-	<div class="inner">
-		<header class="major" style="margin-bottom: 1em;">
-			<h2 style="text-transform: uppercase; color: white;">Video Referrals</h2>
-		</header>
-	</div>
-</section>
-<!-- Section Header Ends -->
-<div class="video-reviews-section" style="width:100%; padding:0 8% 40px; background-color:#218ea6;">
-	<div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); gap:2em; max-width:1100px; margin:0 auto;">
-		<!-- Video 1 -->
-		<div>
-			<iframe class="YT-video" src="https://www.youtube.com/embed/IWCUZTMvbfI?si=sRXMsiIrzrLMO9h8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-		</div>
-		<!-- Video 2 -->
-		<div>
-			<iframe class="YT-video" src="https://www.youtube.com/embed/KXeFs3Vq7Ak?si=BCQbIDEQCR0p19jx" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-		</div>
-		<!-- Video 3 -->
-		<div>
-			<iframe class="YT-video" src="https://www.youtube.com/embed/N0jaQ9dP2ws?si=nynpo89bikYvc3JS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-		</div>
-	</div>
 </div>
 
 <!--   *****   JQuery Link   *****   -->


### PR DESCRIPTION
- Reorder homepage: video referrals + Google Reviews link now sit under 'What Clients Say', above written testimonials
- Add superscript asterisk to every quoted price, tied to the VAT footnote in each pricing popup
- Pricing paragraph wording: 'general guide' + size-aware percentage (2-4% smaller charities, ~1% or less larger)