### PR TITLE
Fix video referrals gap and button contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
 			</div>
 		</section>
 		<div class="center-button" style="padding: 2em 0;">
-			<a href="#referrals" class="button fit">See What Our Clients Say</a>
+			<a href="#referrals" class="button fit primary">See What Our Clients Say</a>
 		</div>
 	<!-- ExpensePlus -->
 	<section id="ExpensePlus" style="margin-top:-200px; margin-bottom: 200px" class="wrapper alt style2"></section>
@@ -182,9 +182,9 @@
 				
 <!--testimonials styling-->
 	<section id="referrals" style="margin-top:-80px; margin-bottom: 80px"></section>
-	<section id="reviews" class="wrapper style1 special" style="background-color: #218ea6!important;">
+	<section id="reviews" class="wrapper style1 special" style="background-color: #218ea6!important; padding-bottom: 0.5em;">
 		<div class="inner">
-			<header class="major">
+			<header class="major" style="margin-bottom: 0.5em;">
 			<h2 style="text-transform: uppercase; color: white;">What Clients Say</h2>
 			</header>
 		</div>


### PR DESCRIPTION
- Tighten the gap between 'What Clients Say' and the line above the videos
- Switch 'See What Our Clients Say' to the solid-fill primary button style so it doesn't blend into the section it sits in